### PR TITLE
Add leases container to Cosmos DB configuration to prevent control plane errors creating the container

### DIFF
--- a/infra/app/db.bicep
+++ b/infra/app/db.bicep
@@ -117,6 +117,23 @@ resource cosmosDbContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/c
   }
 }
  
+
+resource cosmosDbLeasesContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-11-15' = {
+  parent: cosmosDbDatabase
+  name: 'leases'
+  properties: {
+    resource: {
+      id: 'leases'
+      partitionKey: {
+        paths: [
+          '/id'
+        ]
+        kind: 'Hash'
+      }
+    }
+  }
+}
+
 output cosmosDbName string = cosmosDbDatabase.name
 output cosmosDbAccountName string = cosmosDbAccount.name
 output cosmosDbContainer string = cosmosDbContainer.name


### PR DESCRIPTION
## Purpose

Mirrors https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-cosmosdb/pull/7 in this sibling quickstart.

Adds the `leases` container to the Cosmos DB Bicep so that it is pre-provisioned by `azd provision`, instead of being auto-created at runtime by the Cosmos DB trigger.

This avoids intermittent control-plane errors when the Functions host tries to create the lease container at startup (HTTP 403 / Forbidden behind firewalls, throttling on serverless accounts, races on first cold start, etc.). The function binding still has `createLeaseContainerIfNotExists = true`, but it will now find the container already in place.

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

```
[X] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactoring
[ ] Documentation content changes
[ ] Other
```

## How to Test

1. Provision the sample with `azd provision`.
2. Verify the `leases` container exists in the Cosmos DB database alongside `documents`.
3. Deploy the function and write a document to the `documents` container — confirm the `cosmos_trigger` function fires and that the leases container is populated with checkpoint state.

## What to Check

* `infra/app/db.bicep` now declares a `cosmosDbLeasesContainer` resource with partition key `/id` (kind `Hash`) — matching the `LeaseContainerName = "leases"` referenced by the trigger.
* No changes to function code or app settings.

## Other Information

Validated end-to-end on the .NET sibling repo (PR #7): trigger fires, lease docs created with `ContinuationToken`, function execution succeeds.
